### PR TITLE
Incorporating feedback from internal review

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Visit our [Docs pages](https://nyckelai.github.io/python-sdk/)
 ## Quickstart
 
 ```python
-from nyckel import User, TextClassificationFunction
+from nyckel import Credentials, TextClassificationFunction
 
 # Get credentials from https://www.nyckel.com/console/keys
-user = User(client_id=..., client_secret=...)
+credentials = Credentials(client_id=..., client_secret=...)
 
 # Create a new text classification function.
-func = TextClassificationFunction.create(user=user, name="IsToxic")
+func = TextClassificationFunction.create(credentials=credentials, name="IsToxic")
 
 # Provide a few examples.
 func.add_samples([

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ func.add_samples([
 # ...and you can start classifying text right away!
 
 # Classify a new piece of text.
-label = func("New text")
+predictions = func.invoke(["New text"])
 ```
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ from nyckel import User, TextClassificationFunction
 user = User(client_id=..., client_secret=...)
 
 # Create a new text classification function.
-func = TextClassificationFunction.new(user=user, name="IsToxic")
+func = TextClassificationFunction.create(user=user, name="IsToxic")
 
 # Provide a few examples.
 func.add_samples([

--- a/docs/copy_function.md
+++ b/docs/copy_function.md
@@ -12,7 +12,7 @@ user = User(client_id=..., client_secret=...)
 from_func = TextClassificationFunction("<function_id>", user)
 
 # Create a new, empty function.
-to_func = TextClassificationFunction.new(f"{from_func.name} COPY", user)
+to_func = TextClassificationFunction.create(f"{from_func.name} COPY", user)
 
 # Copy samples over. Labels will automatically be created.
 to_func.create_samples(from_func.list_samples())

--- a/docs/copy_function.md
+++ b/docs/copy_function.md
@@ -3,16 +3,16 @@
 Use the Nyckel SDK to quickly copy your Nyckel function to a new function.
 
 ``` py
-from nyckel import User, TextClassificationFunction
+from nyckel import Credentials, TextClassificationFunction
 
 # Get credentials from https://www.nyckel.com/console/keys
-user = User(client_id=..., client_secret=...)
+credentials = Credentials(client_id=..., client_secret=...)
 
 # Load the source function.
-from_func = TextClassificationFunction("<function_id>", user)
+from_func = TextClassificationFunction("<function_id>", credentials)
 
 # Create a new, empty function.
-to_func = TextClassificationFunction.create(f"{from_func.name} COPY", user)
+to_func = TextClassificationFunction.create(f"{from_func.name} COPY", credentials)
 
 # Copy samples over. Labels will automatically be created.
 to_func.create_samples(from_func.list_samples())

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,1 @@
+::: nyckel.Credentials

--- a/docs/delete_label.md
+++ b/docs/delete_label.md
@@ -26,5 +26,5 @@ func.delete_samples([sample.id for sample in samples])
 
 # Delete the label.
 label_id_by_name = {label.name: label.id for label in func.list_labels()}
-func.delete_label(label_id_by_name[label_name])
+func.delete_labels([label_id_by_name[label_name]])
 ```

--- a/docs/delete_label.md
+++ b/docs/delete_label.md
@@ -5,14 +5,14 @@ Deleting a label is easy in the [Nyckel UI](https://www.nyckel.com), [API](https
 This guide shows how to *delete a single label along with all samples associated with it*.
 
 ``` py
-from nyckel import User, TextClassificationFunction
+from nyckel import Credentials, TextClassificationFunction
 
 # This is the label name to be deleted
 label_name = "" 
 
-# Initialize your user and function
-user = User(client_id="...", client_secret="...")
-func = TextClassificationFunction("<function_id>", user)
+# Initialize your credentials and function
+credentials = Credentials(client_id="...", client_secret="...")
+func = TextClassificationFunction("<function_id>", credentials)
 
 # Get all samples
 samples = func.list_samples()

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ from nyckel import User, TextClassificationFunction
 
 user = User(client_id="...", client_secret="...")
 
-func = TextClassificationFunction.new("IsToxic", user)
+func = TextClassificationFunction.create("IsToxic", user)
 func.create_samples([
     ("This is a nice comment", "Not toxic"),
     ("Hello friend", "Not toxic"),

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ func.create_samples([
     ("Who is this? Go away!", "Toxic"),
 ])
 
-prediction = func("This example is fantastic!")
+predictions = func.invoke(["This example is fantastic!"])
 ```
 
 ## Get started

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,11 +3,11 @@
 [Nyckel](https://www.nyckel.com) is a Custom Classification API. It allows you to train, deploy and invoke custom [text](text_classification.md), [image](image_classification.md) and [tabular](tabular_classification.md) classification functions.
 
 ``` py
-from nyckel import User, TextClassificationFunction
+from nyckel import Credentials, TextClassificationFunction
 
-user = User(client_id="...", client_secret="...")
+cred = Credentials(client_id="...", client_secret="...")
 
-func = TextClassificationFunction.create("IsToxic", user)
+func = TextClassificationFunction.create("IsToxic", cred)
 func.create_samples([
     ("This is a nice comment", "Not toxic"),
     ("Hello friend", "Not toxic"),

--- a/docs/merge_labels.md
+++ b/docs/merge_labels.md
@@ -34,5 +34,5 @@ assert len(samples) == 0, "Something went wrong. There are still samples associa
 
 # Delete the first label.
 label_id_by_name = {label.name: label.id for label in func.list_labels()}
-func.delete_label(label_id_by_name[label_to_delete])
+func.delete_labels([label_id_by_name[label_to_delete]])
 ```

--- a/docs/merge_labels.md
+++ b/docs/merge_labels.md
@@ -3,15 +3,15 @@
 This guide shows how to merge two labels leaving all samples associated with the second label.
 
 ``` py
-from nyckel import User, TextClassificationFunction, ClassificationAnnotation, TextClassificationSample
+from nyckel import Credentials, TextClassificationFunction, ClassificationAnnotation, TextClassificationSample
 import time
 
 label_to_delete = ""  # This is the label name of the label to be deleted
 label_to_keep = ""  # This is the label to which we want to assign samples from the first label
 
-# Initialize your user and function
-user = User(client_id="...", client_secret="...")
-func = TextClassificationFunction("<function_id>", user)
+# Initialize your credentials and function
+credentials = Credentials(client_id="...", client_secret="...")
+func = TextClassificationFunction("<function_id>", credentials)
 
 # Get all samples
 samples = func.list_samples()

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,7 +9,7 @@ from nyckel import User, TextClassificationFunction
 user = User(client_id=..., client_secret=...)
 
 # Create a new text classification function.
-func = TextClassificationFunction.new(user=user, name='IsToxic')
+func = TextClassificationFunction.create(user=user, name='IsToxic')
 
 # Provide a few examples.
 func.add_samples([

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,13 +3,13 @@
 Use the Nyckel SDK to train, deploy and invoke a text classification function.
 
 ``` py
-from nyckel import User, TextClassificationFunction
+from nyckel import Credentials, TextClassificationFunction
 
 # Get credentials from https://www.nyckel.com/console/keys
-user = User(client_id=..., client_secret=...)
+credentials = Credentials(client_id=..., client_secret=...)
 
 # Create a new text classification function.
-func = TextClassificationFunction.create(user=user, name='IsToxic')
+func = TextClassificationFunction.create(credentials=credentials, name='IsToxic')
 
 # Provide a few examples.
 func.add_samples([

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,5 +23,5 @@ func.add_samples([
 # ...and you can start classifying text right away!
 
 # Classify a new piece of text.
-prediction = func("This example is fantastic!")
+predictions = func.invoke(["This example is fantastic!"])
 ```

--- a/docs/user.md
+++ b/docs/user.md
@@ -1,1 +1,0 @@
-::: nyckel.User

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ nav:
     - Image Classification: image_classification.md
     - Text Classification: text_classification.md
     - Tabular Classification: tabular_classification.md
-    - User: user.md
+    - Credentials: credentials.md
     - Data classes: data_classes.md
 theme: 
   name: 'material'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/nyckel"]
 
 [project]
 name = "nyckel"
-version = "0.1.8"
+version = "0.1.9"
 authors = [{ name = "Oscar Beijbom", email = "oscar@nyckel.com" }]
 description = "Python package for the Nyckel API"
 readme = "README.md"

--- a/src/nyckel/__init__.py
+++ b/src/nyckel/__init__.py
@@ -1,5 +1,6 @@
-from .auth import User  # noqa: F401
-from .auth import User as OAuth2Renewer  # For backwards compatibility. # noqa: F401
+from .auth import Credentials  # noqa: F401
+from .auth import Credentials as OAuth2Renewer  # For backwards compatibility. # noqa: F401
+from .auth import Credentials as User  # For backwards compatibility. # noqa: F401
 from .data_classes import NyckelId  # noqa: F401
 from .functions.classification.classification import (
     ClassificationAnnotation,  # noqa: F401

--- a/src/nyckel/auth.py
+++ b/src/nyckel/auth.py
@@ -5,13 +5,13 @@ import requests
 from nyckel.request_utils import get_session_that_retries
 
 
-class User:
-    """User authentication for Nyckel. Handles renewal of OAuth2 bearer token.
+class Credentials:
+    """API credentials for Nyckel. Handles renewal of OAuth2 bearer token.
 
     Example:
 
-        user = User(client_id="...", client_secret="...")
-        session = user.get_session()
+        credentials = Credentials(client_id="...", client_secret="...")
+        session = credentials.get_session()
         my_functions = session.get("https://www.nyckel.com/v1/functions")
 
     """

--- a/src/nyckel/auth.py
+++ b/src/nyckel/auth.py
@@ -1,5 +1,6 @@
 import time
 
+import pkg_resources
 import requests
 
 from nyckel.request_utils import get_session_that_retries
@@ -33,10 +34,25 @@ class Credentials:
     def server_url(self) -> str:
         return self._server_url
 
+    @property
+    def client_id(self) -> str:
+        return self._client_id
+
     def get_session(self) -> requests.Session:
         """Returns a requests session with active bearer token header."""
         session = get_session_that_retries()
-        session.headers.update({"Authorization": f"Bearer {self.token}"})
+        try:
+            nyckel_pip_version = pkg_resources.get_distribution("nyckel").version
+        except pkg_resources.DistributionNotFound:
+            nyckel_pip_version = "dev"
+
+        session.headers.update(
+            {
+                "Authorization": f"Bearer {self.token}",
+                "Nyckel-Client-Name": "python-sdk",
+                "Nyckel-Client-Version": nyckel_pip_version,
+            }
+        )
         return session
 
     def _renew_token(self) -> None:

--- a/src/nyckel/functions/classification/classification.py
+++ b/src/nyckel/functions/classification/classification.py
@@ -105,11 +105,6 @@ class ClassificationFunction(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def input_modality(self) -> str:
-        pass
-
-    @property
-    @abc.abstractmethod
     def name(self) -> str:
         pass
 

--- a/src/nyckel/functions/classification/classification.py
+++ b/src/nyckel/functions/classification/classification.py
@@ -81,7 +81,7 @@ ClassificationSample = Union[TextClassificationSample, ImageClassificationSample
 class ClassificationFunction(abc.ABC):
     @classmethod
     @abc.abstractmethod
-    def new(cls, name: str, user: User) -> "ClassificationFunction":
+    def create(cls, name: str, user: User) -> "ClassificationFunction":
         pass
 
     @abc.abstractmethod

--- a/src/nyckel/functions/classification/classification.py
+++ b/src/nyckel/functions/classification/classification.py
@@ -85,6 +85,10 @@ class ClassificationFunction(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def delete(self) -> None:
+        pass
+
+    @abc.abstractmethod
     def __init__(self, function_id: str, credentials: Credentials):
         pass
 
@@ -155,11 +159,6 @@ class ClassificationFunction(abc.ABC):
 
     @abc.abstractmethod
     def delete_samples(self, sample_ids: List[NyckelId]) -> None:
-        pass
-
-    @abc.abstractmethod
-    def delete(self) -> None:
-        """Deletes the function"""
         pass
 
 

--- a/src/nyckel/functions/classification/classification.py
+++ b/src/nyckel/functions/classification/classification.py
@@ -105,11 +105,6 @@ class ClassificationFunction(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def train_page(self) -> str:
-        pass
-
-    @property
-    @abc.abstractmethod
     def input_modality(self) -> str:
         pass
 

--- a/src/nyckel/functions/classification/classification.py
+++ b/src/nyckel/functions/classification/classification.py
@@ -11,7 +11,7 @@ ImageSampleData = str
 """DataUri, Url, or local filepath."""
 
 
-TabularFieldValue = Union[str, int]
+TabularFieldValue = Union[str, float]
 TabularFieldKey = str
 TabularSampleData = Dict[TabularFieldKey, TabularFieldValue]
 
@@ -21,7 +21,7 @@ LabelName = str
 @dataclass
 class ClassificationLabel:
     name: LabelName
-    id: Optional[str] = None
+    id: Optional[NyckelId] = None
     description: Optional[str] = None
     metadata: Optional[Dict[str, str]] = None
 

--- a/src/nyckel/functions/classification/classification.py
+++ b/src/nyckel/functions/classification/classification.py
@@ -139,10 +139,6 @@ class ClassificationFunction(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_label(self, label_id: NyckelId) -> None:
-        pass
-
-    @abc.abstractmethod
     def delete_labels(self, label_ids: List[NyckelId]) -> None:
         pass
 
@@ -160,10 +156,6 @@ class ClassificationFunction(abc.ABC):
 
     @abc.abstractmethod
     def update_annotation(self, sample: ClassificationSample) -> None:
-        pass
-
-    @abc.abstractmethod
-    def delete_sample(self, sample_id: NyckelId) -> None:
         pass
 
     @abc.abstractmethod

--- a/src/nyckel/functions/classification/classification.py
+++ b/src/nyckel/functions/classification/classification.py
@@ -2,7 +2,7 @@ import abc
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
-from nyckel import NyckelId, User
+from nyckel import Credentials, NyckelId
 
 TextSampleData = str
 
@@ -81,11 +81,11 @@ ClassificationSample = Union[TextClassificationSample, ImageClassificationSample
 class ClassificationFunction(abc.ABC):
     @classmethod
     @abc.abstractmethod
-    def create(cls, name: str, user: User) -> "ClassificationFunction":
+    def create(cls, name: str, credentials: Credentials) -> "ClassificationFunction":
         pass
 
     @abc.abstractmethod
-    def __init__(self, function_id: str, user: User):
+    def __init__(self, function_id: str, credentials: Credentials):
         pass
 
     @property

--- a/src/nyckel/functions/classification/classification.py
+++ b/src/nyckel/functions/classification/classification.py
@@ -88,11 +88,6 @@ class ClassificationFunction(abc.ABC):
     def __init__(self, function_id: str, user: User):
         pass
 
-    @abc.abstractmethod
-    def __call__(self, sample_data: str) -> ClassificationPrediction:
-        """Invokes the trained function. Raises ValueError if function is not trained"""
-        pass
-
     @property
     @abc.abstractmethod
     def function_id(self) -> NyckelId:

--- a/src/nyckel/functions/classification/factory.py
+++ b/src/nyckel/functions/classification/factory.py
@@ -44,9 +44,7 @@ class ClassificationFunctionFactory:
                 response = session.get(url)
                 function_is_available = response.status_code == 200
 
-        session = get_session_that_retries()
-        session.headers.update({"authorization": "Bearer " + credentials.token})
-
+        session = credentials.get_session()
         function_id = post_function()
         hold_until_available(function_id)
 

--- a/src/nyckel/functions/classification/factory.py
+++ b/src/nyckel/functions/classification/factory.py
@@ -22,7 +22,7 @@ class ClassificationFunctionFactory:
         return self.function_type_by_input[input_modality](function_id, user)
 
     @classmethod
-    def new(self, name: str, function_input: str, user: User) -> ClassificationFunction:
+    def create(self, name: str, function_input: str, user: User) -> ClassificationFunction:
         def post_function() -> str:
             url = f"{user.server_url}/v1/functions"
             response = session.post(url, json={"input": function_input, "output": "Classification", "name": name})

--- a/src/nyckel/functions/classification/function_handler.py
+++ b/src/nyckel/functions/classification/function_handler.py
@@ -2,14 +2,12 @@ from typing import Dict
 
 from nyckel import Credentials
 from nyckel.functions.classification.classification import ClassificationFunctionURLHandler
-from nyckel.request_utils import get_session_that_retries
 
 
 class ClassificationFunctionHandler:
     def __init__(self, function_id: str, credentials: Credentials):
         self._function_id = function_id
-        self.credentials = credentials
-        self._session = get_session_that_retries()
+        self._credentials = credentials
         self._url_handler = ClassificationFunctionURLHandler(function_id, credentials.server_url)
         self.validate_access()
         assert self.get_output_modality() == "Classification"
@@ -33,16 +31,15 @@ class ClassificationFunctionHandler:
         )
 
     def validate_access(self) -> None:
-        self._refresh_auth_token()
-
         url = self._url_handler.api_endpoint()
-        response = self._session.get(url)
+        session = self._credentials.get_session()
+        response = session.get(url)
 
         if response.status_code == 401:
             raise ValueError(f"Invalid access tokens. Can't access {self._function_id}.")
         if response.status_code == 403:
             raise ValueError(
-                f"Can't access {self._function_id} using credentials with CLIENT_ID: {self.credentials.client_id}."
+                f"Can't access {self._function_id} using credentials with CLIENT_ID: {self._credentials.client_id}."
             )
         elif not response.status_code == 200:
             raise ValueError(
@@ -50,48 +47,45 @@ class ClassificationFunctionHandler:
             )
 
     def get_name(self) -> str:
-        self._refresh_auth_token()
         url = self._url_handler.api_endpoint()
-        response = self._session.get(url)
+        session = self._credentials.get_session()
+        response = session.get(url)
         assert response.status_code == 200
         return response.json()["name"] if "name" in response.json() else "NewFunction"
 
     def get_metrics(self) -> Dict:
-        self._refresh_auth_token()
         url = self._url_handler.api_endpoint(path="metrics", api_version="v0.9")
-        resp = self._session.get(url)
+        session = self._credentials.get_session()
+        resp = session.get(url)
         if not resp.status_code == 200:
             raise RuntimeError(f"Can't get {url=}. {resp.status_code=} {resp.text=}")
         return resp.json()
 
     def get_input_modality(self) -> str:
-        self._refresh_auth_token()
         url = self._url_handler.api_endpoint()
-        response = self._session.get(url)
+        session = self._credentials.get_session()
+        response = session.get(url)
         assert response.status_code == 200, f"{response.text=} {response.status_code=}"
         return response.json()["input"]
 
     def get_output_modality(self) -> str:
-        self._refresh_auth_token()
         url = self._url_handler.api_endpoint()
-        response = self._session.get(url)
+        session = self._credentials.get_session()
+        response = session.get(url)
         assert response.status_code == 200, f"{response.text=} {response.status_code=}"
         return response.json()["output"]
 
     def get_v09_function_meta(self) -> Dict:
-        self._refresh_auth_token()
         url = self._url_handler.api_endpoint(api_version="v0.9")
-        resp = self._session.get(url)
+        session = self._credentials.get_session()
+        resp = session.get(url)
         if not resp.status_code == 200:
             raise RuntimeError(f"Can't get {url=}. {resp.status_code=} {resp.text=}")
         return resp.json()
 
     def delete(self) -> None:
-        self._refresh_auth_token()
-        endpoint = self._url_handler.api_endpoint()
-        response = self._session.delete(endpoint)
+        url = self._url_handler.api_endpoint()
+        session = self._credentials.get_session()
+        response = session.delete(url)
         assert response.status_code == 200, f"Delete failed with {response.status_code=}, {response.text=}"
         print(f"-> Function {self._url_handler.train_page} deleted.")
-
-    def _refresh_auth_token(self) -> None:
-        self._session.headers.update({"authorization": "Bearer " + self.credentials.token})

--- a/src/nyckel/functions/classification/function_handler.py
+++ b/src/nyckel/functions/classification/function_handler.py
@@ -1,16 +1,16 @@
 from typing import Dict
 
-from nyckel import User
+from nyckel import Credentials
 from nyckel.functions.classification.classification import ClassificationFunctionURLHandler
 from nyckel.request_utils import get_session_that_retries
 
 
 class ClassificationFunctionHandler:
-    def __init__(self, function_id: str, user: User):
+    def __init__(self, function_id: str, credentials: Credentials):
         self._function_id = function_id
-        self._user = user
+        self.credentials = credentials
         self._session = get_session_that_retries()
-        self._url_handler = ClassificationFunctionURLHandler(function_id, user.server_url)
+        self._url_handler = ClassificationFunctionURLHandler(function_id, credentials.server_url)
         self.validate_access()
         assert self.get_output_modality() == "Classification"
 
@@ -42,7 +42,7 @@ class ClassificationFunctionHandler:
             raise ValueError(f"Invalid access tokens. Can't access {self._function_id}.")
         if response.status_code == 403:
             raise ValueError(
-                f"Can't access {self._function_id} using credentials with CLIENT_ID: {self._user.client_id}."
+                f"Can't access {self._function_id} using credentials with CLIENT_ID: {self.credentials.client_id}."
             )
         elif not response.status_code == 200:
             raise ValueError(
@@ -94,4 +94,4 @@ class ClassificationFunctionHandler:
         print(f"-> Function {self._url_handler.train_page} deleted.")
 
     def _refresh_auth_token(self) -> None:
-        self._session.headers.update({"authorization": "Bearer " + self._user.token})
+        self._session.headers.update({"authorization": "Bearer " + self.credentials.token})

--- a/src/nyckel/functions/classification/image_classification.py
+++ b/src/nyckel/functions/classification/image_classification.py
@@ -109,9 +109,6 @@ class ImageClassificationFunction(ClassificationFunction):
     def update_label(self, label: ClassificationLabel) -> ClassificationLabel:
         return self._label_handler.update_label(label)
 
-    def delete_label(self, label_id: NyckelId) -> None:
-        return self._label_handler.delete_label(label_id)
-
     def delete_labels(self, label_ids: List[NyckelId]) -> None:
         return self._label_handler.delete_labels(label_ids)
 
@@ -150,9 +147,6 @@ class ImageClassificationFunction(ClassificationFunction):
 
     def update_annotation(self, sample: ImageClassificationSample) -> None:  # type: ignore
         self._sample_handler.update_annotation(sample)
-
-    def delete_sample(self, sample_id: NyckelId) -> None:
-        self._sample_handler.delete_sample(sample_id)
 
     def delete_samples(self, sample_ids: List[NyckelId]) -> None:
         self._sample_handler.delete_samples(sample_ids)

--- a/src/nyckel/functions/classification/image_classification.py
+++ b/src/nyckel/functions/classification/image_classification.py
@@ -84,10 +84,6 @@ class ImageClassificationFunction(ClassificationFunction):
         return self._function_handler.label_count
 
     @property
-    def input_modality(self) -> str:
-        return "Image"
-
-    @property
     def name(self) -> str:
         return self._function_handler.get_name()
 

--- a/src/nyckel/functions/classification/image_classification.py
+++ b/src/nyckel/functions/classification/image_classification.py
@@ -60,10 +60,6 @@ class ImageClassificationFunction(ClassificationFunction):
         self._encoder = ImageEncoder()
         assert self._function_handler.get_input_modality() == "Image"
 
-    @classmethod
-    def create(cls, name: str, credentials: Credentials) -> "ImageClassificationFunction":
-        return factory.ClassificationFunctionFactory.create(name, "Image", credentials)  # type: ignore
-
     def __str__(self) -> str:
         return self.__repr__()
 
@@ -86,6 +82,13 @@ class ImageClassificationFunction(ClassificationFunction):
     @property
     def name(self) -> str:
         return self._function_handler.get_name()
+
+    @classmethod
+    def create(cls, name: str, credentials: Credentials) -> "ImageClassificationFunction":
+        return factory.ClassificationFunctionFactory.create(name, "Image", credentials)  # type: ignore
+
+    def delete(self) -> None:
+        self._function_handler.delete()
 
     def invoke(self, sample_data_list: List[ImageSampleData]) -> List[ClassificationPrediction]:
         return self._sample_handler.invoke(sample_data_list, self._sample_data_to_body)
@@ -146,9 +149,6 @@ class ImageClassificationFunction(ClassificationFunction):
 
     def delete_samples(self, sample_ids: List[NyckelId]) -> None:
         self._sample_handler.delete_samples(sample_ids)
-
-    def delete(self) -> None:
-        self._function_handler.delete()
 
     def _resize_image(self, img: Image.Image) -> Image.Image:
         def get_new_width_height(width: int, height: int) -> Tuple[int, int]:

--- a/src/nyckel/functions/classification/image_classification.py
+++ b/src/nyckel/functions/classification/image_classification.py
@@ -68,7 +68,7 @@ class ImageClassificationFunction(ClassificationFunction):
         return self.__repr__()
 
     def __repr__(self) -> str:
-        status_string = f"Name: {self.name}, id: {self.function_id}, url: {self.train_page}"
+        status_string = f"Name: {self.name}, id: {self.function_id}, url: {self._url_handler.train_page}"
         return status_string
 
     @property
@@ -82,10 +82,6 @@ class ImageClassificationFunction(ClassificationFunction):
     @property
     def label_count(self) -> int:
         return self._function_handler.label_count
-
-    @property
-    def train_page(self) -> str:
-        return self._url_handler.train_page
 
     @property
     def input_modality(self) -> str:

--- a/src/nyckel/functions/classification/image_classification.py
+++ b/src/nyckel/functions/classification/image_classification.py
@@ -1,7 +1,7 @@
 import base64
 import os
 from io import BytesIO
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Sequence, Tuple, Union
 
 import requests
 from PIL import Image
@@ -42,7 +42,7 @@ class ImageClassificationFunction(ClassificationFunction):
         ("dog2.jpg", "dog")
     ])
 
-    prediction = func("cat_or_dog.jpg")
+    predictions = func.invoke(["cat_or_dog.jpg"])
     ```
     """
 
@@ -75,9 +75,6 @@ class ImageClassificationFunction(ClassificationFunction):
     def __repr__(self) -> str:
         status_string = f"Name: {self.name}, id: {self.function_id}, url: {self.train_page}"
         return status_string
-
-    def __call__(self, sample_data: ImageSampleData) -> ClassificationPrediction:
-        return self.invoke([sample_data])[0]
 
     @property
     def function_id(self) -> NyckelId:
@@ -133,7 +130,7 @@ class ImageClassificationFunction(ClassificationFunction):
 
     def create_samples(
         self,
-        samples: List[  # type: ignore
+        samples: Sequence[  # type: ignore
             Union[
                 ImageClassificationSample,
                 Tuple[Image.Image, LabelName],
@@ -244,7 +241,7 @@ class ImageClassificationFunction(ClassificationFunction):
 
     def _wrangle_post_samples_input(
         self,
-        samples: List[  # type: ignore
+        samples: Sequence[
             Union[
                 ImageClassificationSample,
                 Tuple[Image.Image, LabelName],

--- a/src/nyckel/functions/classification/image_classification.py
+++ b/src/nyckel/functions/classification/image_classification.py
@@ -11,11 +11,11 @@ from nyckel import (
     ClassificationFunction,
     ClassificationLabel,
     ClassificationPrediction,
+    Credentials,
     ImageClassificationSample,
     ImageSampleData,
     LabelName,
     NyckelId,
-    User,
 )
 from nyckel.functions.classification import factory
 from nyckel.functions.classification.classification import ClassificationFunctionURLHandler
@@ -30,11 +30,11 @@ class ImageClassificationFunction(ClassificationFunction):
     Example:
 
     ```py
-    from nyckel import User, ImageClassificationFunction
+    from nyckel import Credentials, ImageClassificationFunction
 
-    user = User(client_id="...", client_secret="...")
+    credentials = Credentials(client_id="...", client_secret="...")
 
-    func = ImageClassificationFunction.create("IsCatOrDog", user)
+    func = ImageClassificationFunction.create("IsCatOrDog", credentials)
     func.create_samples([
         ("cat1.jpg", "cat"),
         ("cat2.jpg", "cat"),
@@ -47,23 +47,22 @@ class ImageClassificationFunction(ClassificationFunction):
     """
 
     def __init__(
-        self, function_id: str, user: User, target_largest_side: int = 1024, force_recode: bool = True
+        self, function_id: str, credentials: Credentials, target_largest_side: int = 1024, force_recode: bool = True
     ) -> None:
         self._function_id = function_id
-        self._user = user
         self._target_largest_side = target_largest_side
         self._force_recode = force_recode  # Whether to resize & recode images before uploading them.
-        self._function_handler = ClassificationFunctionHandler(function_id, user)
-        self._label_handler = ClassificationLabelHandler(function_id, user)
-        self._url_handler = ClassificationFunctionURLHandler(function_id, user.server_url)
-        self._sample_handler = ClassificationSampleHandler(function_id, user)
+        self._function_handler = ClassificationFunctionHandler(function_id, credentials)
+        self._label_handler = ClassificationLabelHandler(function_id, credentials)
+        self._url_handler = ClassificationFunctionURLHandler(function_id, credentials.server_url)
+        self._sample_handler = ClassificationSampleHandler(function_id, credentials)
         self._decoder = ImageDecoder()
         self._encoder = ImageEncoder()
         assert self._function_handler.get_input_modality() == "Image"
 
     @classmethod
-    def create(cls, name: str, user: User) -> "ImageClassificationFunction":
-        return factory.ClassificationFunctionFactory.create(name, "Image", user)  # type: ignore
+    def create(cls, name: str, credentials: Credentials) -> "ImageClassificationFunction":
+        return factory.ClassificationFunctionFactory.create(name, "Image", credentials)  # type: ignore
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/src/nyckel/functions/classification/image_classification.py
+++ b/src/nyckel/functions/classification/image_classification.py
@@ -91,10 +91,6 @@ class ImageClassificationFunction(ClassificationFunction):
     def name(self) -> str:
         return self._function_handler.get_name()
 
-    @property
-    def metrics(self) -> Dict:
-        return self._function_handler.get_metrics()
-
     def invoke(self, sample_data_list: List[ImageSampleData]) -> List[ClassificationPrediction]:
         return self._sample_handler.invoke(sample_data_list, self._sample_data_to_body)
 

--- a/src/nyckel/functions/classification/image_classification.py
+++ b/src/nyckel/functions/classification/image_classification.py
@@ -34,7 +34,7 @@ class ImageClassificationFunction(ClassificationFunction):
 
     user = User(client_id="...", client_secret="...")
 
-    func = ImageClassificationFunction.new("IsCatOrDog", user)
+    func = ImageClassificationFunction.create("IsCatOrDog", user)
     func.create_samples([
         ("cat1.jpg", "cat"),
         ("cat2.jpg", "cat"),
@@ -62,12 +62,8 @@ class ImageClassificationFunction(ClassificationFunction):
         assert self._function_handler.get_input_modality() == "Image"
 
     @classmethod
-    def new(cls, name: str, user: User) -> "ImageClassificationFunction":
-        return factory.ClassificationFunctionFactory.new(name, "Image", user)  # type: ignore
-
-    @classmethod
-    def create_function(cls, name: str, user: User) -> "ImageClassificationFunction":
-        return cls.new(name, user)
+    def create(cls, name: str, user: User) -> "ImageClassificationFunction":
+        return factory.ClassificationFunctionFactory.create(name, "Image", user)  # type: ignore
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/src/nyckel/functions/classification/label_handler.py
+++ b/src/nyckel/functions/classification/label_handler.py
@@ -77,11 +77,6 @@ class ClassificationLabelHandler:
         assert response.status_code == 200, f"Update failed with {response.status_code=}, {response.text=}"
         return label
 
-    def delete_label(self, label_id: NyckelId) -> None:
-        self._refresh_auth_token()
-        response = self._session.delete(self._url_handler.api_endpoint(path=f"labels/{strip_nyckel_prefix(label_id)}"))
-        assert response.status_code == 200, f"Delete failed with {response.status_code=}, {response.text=}"
-
     def delete_labels(self, label_ids: List[str]) -> None:
         if len(label_ids) == 0:
             return None

--- a/src/nyckel/functions/classification/label_handler.py
+++ b/src/nyckel/functions/classification/label_handler.py
@@ -3,21 +3,21 @@ from typing import Dict, List, Optional
 
 from tqdm import tqdm
 
-from nyckel import ClassificationLabel, NyckelId, User
+from nyckel import ClassificationLabel, Credentials, NyckelId
 from nyckel.functions.classification.classification import ClassificationFunctionURLHandler
 from nyckel.functions.utils import strip_nyckel_prefix
 from nyckel.request_utils import ParallelDeleter, ParallelPoster, SequentialGetter, get_session_that_retries
 
 
 class ClassificationLabelHandler:
-    def __init__(self, function_id: str, user: User):
+    def __init__(self, function_id: str, credentials: Credentials):
         self._function_id = function_id
-        self._user = user
-        self._url_handler = ClassificationFunctionURLHandler(function_id, user.server_url)
+        self.credentials = credentials
+        self._url_handler = ClassificationFunctionURLHandler(function_id, credentials.server_url)
         self._session = get_session_that_retries()
 
     def _refresh_auth_token(self) -> None:
-        self._session.headers.update({"authorization": "Bearer " + self._user.token})
+        self._session.headers.update({"authorization": "Bearer " + self.credentials.token})
 
     def create_labels(self, labels: List[ClassificationLabel]) -> List[str]:
         self._refresh_auth_token()

--- a/src/nyckel/functions/classification/sample_handler.py
+++ b/src/nyckel/functions/classification/sample_handler.py
@@ -129,12 +129,6 @@ class ClassificationSampleHandler:
             response = self._session.delete(url)
             assert response.status_code == 200, f"Delete failed with {response.status_code=}, {response.text=}"
 
-    def delete_sample(self, sample_id: str) -> None:
-        self._refresh_auth_token()
-        endpoint = self._url_handler.api_endpoint(path=f"samples/{strip_nyckel_prefix(sample_id)}")
-        response = self._session.delete(endpoint)
-        assert response.status_code == 200, f"Delete failed with {response.status_code=}, {response.text=}"
-
     def delete_samples(self, sample_ids: List[str]) -> None:
         if len(sample_ids) == 0:
             return None

--- a/src/nyckel/functions/classification/sample_handler.py
+++ b/src/nyckel/functions/classification/sample_handler.py
@@ -6,10 +6,10 @@ from tqdm import tqdm
 from nyckel import (
     ClassificationPrediction,
     ClassificationSample,
+    Credentials,
     ImageClassificationSample,
     TabularClassificationSample,
     TextClassificationSample,
-    User,
 )
 from nyckel.functions.classification.classification import ClassificationFunctionURLHandler
 from nyckel.functions.utils import strip_nyckel_prefix
@@ -21,11 +21,11 @@ ClassificationSampleList = Union[
 
 
 class ClassificationSampleHandler:
-    def __init__(self, function_id: str, user: User):
+    def __init__(self, function_id: str, credentials: Credentials):
         self._function_id = function_id
-        self._user = user
+        self.credentials = credentials
         self._session = get_session_that_retries()
-        self._url_handler = ClassificationFunctionURLHandler(function_id, user.server_url)
+        self._url_handler = ClassificationFunctionURLHandler(function_id, credentials.server_url)
         self._refresh_auth_token()
 
     def invoke(
@@ -146,4 +146,4 @@ class ClassificationSampleHandler:
         parallel_deleter(sample_ids)
 
     def _refresh_auth_token(self) -> None:
-        self._session.headers.update({"authorization": "Bearer " + self._user.token})
+        self._session.headers.update({"authorization": "Bearer " + self.credentials.token})

--- a/src/nyckel/functions/classification/sample_handler.py
+++ b/src/nyckel/functions/classification/sample_handler.py
@@ -90,9 +90,14 @@ class ClassificationSampleHandler:
 
         poster = ParallelPoster(self._session, endpoint, desc="Posting samples", body_transformer=body_transformer)
         response_list = poster(bodies)
-        sample_ids = [
-            strip_nyckel_prefix(response.json()["id"]) for response in response_list if response.status_code == 200
-        ]
+
+        sample_ids = []
+        for response in response_list:
+            if response.status_code == 200:
+                sample_ids.append(strip_nyckel_prefix(response.json()["id"]))
+            if response.status_code == 409:
+                sample_ids.append(strip_nyckel_prefix(response.json()["existingSampleId"]))
+
         return sample_ids
 
     def read_sample(self, sample_id: str) -> Dict:

--- a/src/nyckel/functions/classification/tabular_classification.py
+++ b/src/nyckel/functions/classification/tabular_classification.py
@@ -1,6 +1,6 @@
 import numbers
 import time
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Sequence, Tuple, Union
 
 from tqdm import tqdm
 
@@ -44,7 +44,7 @@ class TabularClassificationFunction(ClassificationFunction):
         ({"Name": "Devin Duncan", "Response": "Nope. Please stop bugging me."}, "Not Interested"),
     ])
 
-    prediction = func({"Name": "Frank Fisher", "Response": "Yea, I'd love to try the Nyckel API!"})
+    predictions = func.invoke([{"Name": "Frank Fisher", "Response": "Yea, I'd love to try the Nyckel API!"}])
     ```
     """
 
@@ -73,9 +73,6 @@ class TabularClassificationFunction(ClassificationFunction):
     def __repr__(self) -> str:
         status_string = f"Name: {self.name}, id: {self.function_id}, url: {self.train_page}"
         return status_string
-
-    def __call__(self, sample_data: TabularSampleData) -> ClassificationPrediction:  # type: ignore
-        return self.invoke([sample_data])[0]
 
     @property
     def function_id(self) -> str:
@@ -129,7 +126,7 @@ class TabularClassificationFunction(ClassificationFunction):
     def delete_labels(self, label_ids: List[NyckelId]) -> None:
         return self._label_handler.delete_labels(label_ids)
 
-    def create_samples(self, samples: List[Union[TabularClassificationSample, Tuple[TabularSampleData, LabelName], TabularSampleData]]) -> List[NyckelId]:  # type: ignore # noqa: E501
+    def create_samples(self, samples: Sequence[Union[TabularClassificationSample, Tuple[TabularSampleData, LabelName], TabularSampleData]]) -> List[NyckelId]:  # type: ignore # noqa: E501
         if len(samples) == 0:
             return []
 
@@ -185,8 +182,8 @@ class TabularClassificationFunction(ClassificationFunction):
 
     def _wrangle_post_samples_input(
         self,
-        samples: List[Union[TabularClassificationSample, Tuple[TabularSampleData, LabelName], TabularSampleData]],
-    ) -> List[TabularClassificationSample]:  # type: ignore # noqa: E501
+        samples: Sequence[Union[TabularClassificationSample, Tuple[TabularSampleData, LabelName], TabularSampleData]],
+    ) -> List[TabularClassificationSample]:
         typed_samples: List[TabularClassificationSample] = []
         for sample in samples:
             if isinstance(sample, TabularClassificationSample):

--- a/src/nyckel/functions/classification/tabular_classification.py
+++ b/src/nyckel/functions/classification/tabular_classification.py
@@ -89,10 +89,6 @@ class TabularClassificationFunction(ClassificationFunction):
     def name(self) -> str:
         return self._function_handler.get_name()
 
-    @property
-    def metrics(self) -> Dict:
-        return self._function_handler.get_metrics()
-
     def invoke(self, sample_data_list: List[TabularSampleData]) -> List[ClassificationPrediction]:  # type: ignore
         return self._sample_handler.invoke(sample_data_list, lambda x: x)
 

--- a/src/nyckel/functions/classification/tabular_classification.py
+++ b/src/nyckel/functions/classification/tabular_classification.py
@@ -107,9 +107,6 @@ class TabularClassificationFunction(ClassificationFunction):
     def update_label(self, label: ClassificationLabel) -> ClassificationLabel:
         return self._label_handler.update_label(label)
 
-    def delete_label(self, label_id: NyckelId) -> None:
-        return self._label_handler.delete_label(label_id)
-
     def delete_labels(self, label_ids: List[NyckelId]) -> None:
         return self._label_handler.delete_labels(label_ids)
 
@@ -157,9 +154,6 @@ class TabularClassificationFunction(ClassificationFunction):
 
     def update_annotation(self, sample: TabularClassificationSample) -> None:  # type: ignore
         self._sample_handler.update_annotation(sample)
-
-    def delete_sample(self, sample_id: NyckelId) -> None:
-        self._sample_handler.delete_sample(sample_id)
 
     def delete_samples(self, sample_ids: List[NyckelId]) -> None:
         self._sample_handler.delete_samples(sample_ids)

--- a/src/nyckel/functions/classification/tabular_classification.py
+++ b/src/nyckel/functions/classification/tabular_classification.py
@@ -36,7 +36,7 @@ class TabularClassificationFunction(ClassificationFunction):
 
     user = User(client_id="...", client_secret="...")
 
-    func = TabularClassificationFunction.new("InterestedProspect", user)
+    func = TabularClassificationFunction.create("InterestedProspect", user)
     func.create_samples([
         ({"Name": "Adam Adams", "Response": "Thanks for reaching out. I'd love to chat"}, "Interested"),
         ({"Name": "Bo Berg", "Response": "Sure! Can you tell me a bit more?"}, "Interested"),
@@ -60,12 +60,8 @@ class TabularClassificationFunction(ClassificationFunction):
         assert self._function_handler.get_input_modality() == "Tabular"
 
     @classmethod
-    def new(cls, name: str, user: User) -> "TabularClassificationFunction":
-        return factory.ClassificationFunctionFactory.new(name, "Tabular", user)  # type: ignore
-
-    @classmethod
-    def create_function(cls, name: str, user: User) -> "TabularClassificationFunction":
-        return cls.new(name, user)
+    def create(cls, name: str, user: User) -> "TabularClassificationFunction":
+        return factory.ClassificationFunctionFactory.create(name, "Tabular", user)  # type: ignore
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/src/nyckel/functions/classification/tabular_classification.py
+++ b/src/nyckel/functions/classification/tabular_classification.py
@@ -66,7 +66,7 @@ class TabularClassificationFunction(ClassificationFunction):
         return self.__repr__()
 
     def __repr__(self) -> str:
-        status_string = f"Name: {self.name}, id: {self.function_id}, url: {self.train_page}"
+        status_string = f"Name: {self.name}, id: {self.function_id}, url: {self._url_handler.train_page}"
         return status_string
 
     @property
@@ -80,10 +80,6 @@ class TabularClassificationFunction(ClassificationFunction):
     @property
     def label_count(self) -> int:
         return self._function_handler.label_count
-
-    @property
-    def train_page(self) -> str:
-        return self._url_handler.train_page
 
     @property
     def input_modality(self) -> str:

--- a/src/nyckel/functions/classification/tabular_classification.py
+++ b/src/nyckel/functions/classification/tabular_classification.py
@@ -58,10 +58,6 @@ class TabularClassificationFunction(ClassificationFunction):
         self._url_handler = ClassificationFunctionURLHandler(function_id, credentials.server_url)
         assert self._function_handler.get_input_modality() == "Tabular"
 
-    @classmethod
-    def create(cls, name: str, credentials: Credentials) -> "TabularClassificationFunction":
-        return factory.ClassificationFunctionFactory.create(name, "Tabular", credentials)  # type: ignore
-
     def __str__(self) -> str:
         return self.__repr__()
 
@@ -84,6 +80,13 @@ class TabularClassificationFunction(ClassificationFunction):
     @property
     def name(self) -> str:
         return self._function_handler.get_name()
+
+    @classmethod
+    def create(cls, name: str, credentials: Credentials) -> "TabularClassificationFunction":
+        return factory.ClassificationFunctionFactory.create(name, "Tabular", credentials)  # type: ignore
+
+    def delete(self) -> None:
+        self._function_handler.delete()
 
     def invoke(self, sample_data_list: List[TabularSampleData]) -> List[ClassificationPrediction]:  # type: ignore
         return self._sample_handler.invoke(sample_data_list, lambda x: x)
@@ -153,9 +156,6 @@ class TabularClassificationFunction(ClassificationFunction):
 
     def delete_samples(self, sample_ids: List[NyckelId]) -> None:
         self._sample_handler.delete_samples(sample_ids)
-
-    def delete(self) -> None:
-        self._function_handler.delete()
 
     def _wrangle_post_samples_input(
         self,

--- a/src/nyckel/functions/classification/tabular_classification.py
+++ b/src/nyckel/functions/classification/tabular_classification.py
@@ -82,10 +82,6 @@ class TabularClassificationFunction(ClassificationFunction):
         return self._function_handler.label_count
 
     @property
-    def input_modality(self) -> str:
-        return "Tabular"
-
-    @property
     def name(self) -> str:
         return self._function_handler.get_name()
 

--- a/src/nyckel/functions/classification/text_classification.py
+++ b/src/nyckel/functions/classification/text_classification.py
@@ -29,7 +29,7 @@ class TextClassificationFunction(ClassificationFunction):
 
     user = User(client_id="...", client_secret="...")
 
-    func = TextClassificationFunction.new("IsToxic", user)
+    func = TextClassificationFunction.create("IsToxic", user)
     func.create_samples([
         ("This is a nice comment", "Not toxic"),
         ("Hello friend", "Not toxic"),
@@ -53,12 +53,8 @@ class TextClassificationFunction(ClassificationFunction):
         assert self._function_handler.get_input_modality() == "Text"
 
     @classmethod
-    def new(cls, name: str, user: User) -> "TextClassificationFunction":
-        return factory.ClassificationFunctionFactory.new(name, "Text", user)  # type:ignore
-
-    @classmethod
-    def create_function(cls, name: str, user: User) -> "TextClassificationFunction":
-        return cls.new(name, user)
+    def create(cls, name: str, user: User) -> "TextClassificationFunction":
+        return factory.ClassificationFunctionFactory.create(name, "Text", user)  # type:ignore
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/src/nyckel/functions/classification/text_classification.py
+++ b/src/nyckel/functions/classification/text_classification.py
@@ -59,7 +59,7 @@ class TextClassificationFunction(ClassificationFunction):
         return self.__repr__()
 
     def __repr__(self) -> str:
-        status_string = f"Name: {self.name}, id: {self.function_id}, url: {self.train_page}"
+        status_string = f"Name: {self.name}, id: {self.function_id}, url: {self._url_handler.train_page}"
         return status_string
 
     @property
@@ -73,10 +73,6 @@ class TextClassificationFunction(ClassificationFunction):
     @property
     def label_count(self) -> int:
         return self._function_handler.label_count
-
-    @property
-    def train_page(self) -> str:
-        return self._url_handler.train_page
 
     @property
     def input_modality(self) -> str:

--- a/src/nyckel/functions/classification/text_classification.py
+++ b/src/nyckel/functions/classification/text_classification.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Sequence, Tuple, Union
 
 from nyckel import (
     ClassificationAnnotation,
@@ -37,7 +37,7 @@ class TextClassificationFunction(ClassificationFunction):
         ("Who is this? Go away!", "Toxic"),
     ])
 
-    prediction = func("This example is fantastic!")
+    predictions = func.invoke(["This example is fantastic!"])
     ```
     """
 
@@ -66,9 +66,6 @@ class TextClassificationFunction(ClassificationFunction):
     def __repr__(self) -> str:
         status_string = f"Name: {self.name}, id: {self.function_id}, url: {self.train_page}"
         return status_string
-
-    def __call__(self, sample_data: TextSampleData) -> ClassificationPrediction:
-        return self.invoke([sample_data])[0]
 
     @property
     def function_id(self) -> str:
@@ -123,7 +120,7 @@ class TextClassificationFunction(ClassificationFunction):
         return self._label_handler.delete_labels(label_ids)
 
     def create_samples(
-        self, samples: List[Union[TextClassificationSample, Tuple[TextSampleData, LabelName], TextSampleData]]  # type: ignore  # noqa: E501
+        self, samples: Sequence[Union[TextClassificationSample, Tuple[TextSampleData, LabelName], TextSampleData]]  # type: ignore  # noqa: E501
     ) -> List[NyckelId]:
         typed_samples = self._wrangle_post_samples_input(samples)
         self._create_labels_as_needed(typed_samples)
@@ -181,7 +178,7 @@ class TextClassificationFunction(ClassificationFunction):
         )
 
     def _wrangle_post_samples_input(
-        self, samples: List[Union[TextClassificationSample, Tuple[TextSampleData, LabelName], TextSampleData]]
+        self, samples: Sequence[Union[TextClassificationSample, Tuple[TextSampleData, LabelName], TextSampleData]]
     ) -> List[TextClassificationSample]:
         typed_samples: List[TextClassificationSample] = []
         for sample in samples:

--- a/src/nyckel/functions/classification/text_classification.py
+++ b/src/nyckel/functions/classification/text_classification.py
@@ -82,10 +82,6 @@ class TextClassificationFunction(ClassificationFunction):
     def name(self) -> str:
         return self._function_handler.get_name()
 
-    @property
-    def metrics(self) -> Dict:
-        return self._function_handler.get_metrics()
-
     def invoke(self, sample_data_list: List[TextSampleData]) -> List[ClassificationPrediction]:
         return self._sample_handler.invoke(sample_data_list, lambda x: x)
 

--- a/src/nyckel/functions/classification/text_classification.py
+++ b/src/nyckel/functions/classification/text_classification.py
@@ -5,11 +5,11 @@ from nyckel import (
     ClassificationFunction,
     ClassificationLabel,
     ClassificationPrediction,
+    Credentials,
     LabelName,
     NyckelId,
     TextClassificationSample,
     TextSampleData,
-    User,
 )
 from nyckel.functions.classification import factory
 from nyckel.functions.classification.classification import ClassificationFunctionURLHandler
@@ -25,11 +25,11 @@ class TextClassificationFunction(ClassificationFunction):
 
     ```py
 
-    from nyckel import User, TextClassificationFunction
+    from nyckel import Credentials, TextClassificationFunction
 
-    user = User(client_id="...", client_secret="...")
+    credentials = Credentials(client_id="...", client_secret="...")
 
-    func = TextClassificationFunction.create("IsToxic", user)
+    func = TextClassificationFunction.create("IsToxic", credentials)
     func.create_samples([
         ("This is a nice comment", "Not toxic"),
         ("Hello friend", "Not toxic"),
@@ -41,20 +41,19 @@ class TextClassificationFunction(ClassificationFunction):
     ```
     """
 
-    def __init__(self, function_id: NyckelId, user: User):
+    def __init__(self, function_id: NyckelId, credentials: Credentials):
         self._function_id = function_id
-        self._user = user
 
-        self._function_handler = ClassificationFunctionHandler(function_id, user)
-        self._label_handler = ClassificationLabelHandler(function_id, user)
-        self._url_handler = ClassificationFunctionURLHandler(function_id, user.server_url)
-        self._sample_handler = ClassificationSampleHandler(function_id, user)
+        self._function_handler = ClassificationFunctionHandler(function_id, credentials)
+        self._label_handler = ClassificationLabelHandler(function_id, credentials)
+        self._url_handler = ClassificationFunctionURLHandler(function_id, credentials.server_url)
+        self._sample_handler = ClassificationSampleHandler(function_id, credentials)
 
         assert self._function_handler.get_input_modality() == "Text"
 
     @classmethod
-    def create(cls, name: str, user: User) -> "TextClassificationFunction":
-        return factory.ClassificationFunctionFactory.create(name, "Text", user)  # type:ignore
+    def create(cls, name: str, credentials: Credentials) -> "TextClassificationFunction":
+        return factory.ClassificationFunctionFactory.create(name, "Text", credentials)  # type:ignore
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/src/nyckel/functions/classification/text_classification.py
+++ b/src/nyckel/functions/classification/text_classification.py
@@ -100,9 +100,6 @@ class TextClassificationFunction(ClassificationFunction):
     def update_label(self, label: ClassificationLabel) -> ClassificationLabel:
         return self._label_handler.update_label(label)
 
-    def delete_label(self, label_id: NyckelId) -> None:
-        return self._label_handler.delete_label(label_id)
-
     def delete_labels(self, label_ids: List[NyckelId]) -> None:
         return self._label_handler.delete_labels(label_ids)
 
@@ -132,9 +129,6 @@ class TextClassificationFunction(ClassificationFunction):
 
     def update_annotation(self, sample: TextClassificationSample) -> None:  # type: ignore
         self._sample_handler.update_annotation(sample)
-
-    def delete_sample(self, sample_id: NyckelId) -> None:
-        self._sample_handler.delete_sample(sample_id)
 
     def delete_samples(self, sample_ids: List[NyckelId]) -> None:
         self._sample_handler.delete_samples(sample_ids)

--- a/src/nyckel/functions/classification/text_classification.py
+++ b/src/nyckel/functions/classification/text_classification.py
@@ -75,10 +75,6 @@ class TextClassificationFunction(ClassificationFunction):
         return self._function_handler.label_count
 
     @property
-    def input_modality(self) -> str:
-        return "Text"
-
-    @property
     def name(self) -> str:
         return self._function_handler.get_name()
 

--- a/src/nyckel/functions/classification/text_classification.py
+++ b/src/nyckel/functions/classification/text_classification.py
@@ -51,10 +51,6 @@ class TextClassificationFunction(ClassificationFunction):
 
         assert self._function_handler.get_input_modality() == "Text"
 
-    @classmethod
-    def create(cls, name: str, credentials: Credentials) -> "TextClassificationFunction":
-        return factory.ClassificationFunctionFactory.create(name, "Text", credentials)  # type:ignore
-
     def __str__(self) -> str:
         return self.__repr__()
 
@@ -77,6 +73,13 @@ class TextClassificationFunction(ClassificationFunction):
     @property
     def name(self) -> str:
         return self._function_handler.get_name()
+
+    @classmethod
+    def create(cls, name: str, credentials: Credentials) -> "TextClassificationFunction":
+        return factory.ClassificationFunctionFactory.create(name, "Text", credentials)  # type:ignore
+
+    def delete(self) -> None:
+        self._function_handler.delete()
 
     def invoke(self, sample_data_list: List[TextSampleData]) -> List[ClassificationPrediction]:
         return self._sample_handler.invoke(sample_data_list, lambda x: x)
@@ -128,9 +131,6 @@ class TextClassificationFunction(ClassificationFunction):
 
     def delete_samples(self, sample_ids: List[NyckelId]) -> None:
         self._sample_handler.delete_samples(sample_ids)
-
-    def delete(self) -> None:
-        self._function_handler.delete()
 
     def _sample_from_dict(self, sample_dict: Dict, label_name_by_id: Dict[NyckelId, str]) -> TextClassificationSample:
         if "annotation" in sample_dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,14 +45,14 @@ def auth_test_user() -> Iterator[User]:
 
 @pytest.fixture
 def text_classification_function(auth_test_user: User) -> Iterator[TextClassificationFunction]:
-    func = TextClassificationFunction.create_function("PYTHON-SDK TEXT TEST FUNCTION", auth_test_user)
+    func = TextClassificationFunction.create("PYTHON-SDK TEXT TEST FUNCTION", auth_test_user)
     yield func
     func.delete()
 
 
 @pytest.fixture
 def text_classification_function_with_content(auth_test_user: User) -> Iterator[TextClassificationFunction]:
-    func = TextClassificationFunction.create_function("PYTHON-SDK TEXT TEST FUNCTION", auth_test_user)
+    func = TextClassificationFunction.create("PYTHON-SDK TEXT TEST FUNCTION", auth_test_user)
     labels_to_create = [ClassificationLabel(name="Nice"), ClassificationLabel(name="Boo")]
     func.create_labels(labels_to_create)
     nice = ClassificationAnnotation(label_name="Nice")
@@ -72,14 +72,14 @@ def text_classification_function_with_content(auth_test_user: User) -> Iterator[
 
 @pytest.fixture
 def image_classification_function(auth_test_user: User) -> Iterator[ImageClassificationFunction]:
-    func = ImageClassificationFunction.create_function("PYTHON-SDK IMAGE TEST FUNCTION", auth_test_user)
+    func = ImageClassificationFunction.create("PYTHON-SDK IMAGE TEST FUNCTION", auth_test_user)
     yield func
     func.delete()
 
 
 @pytest.fixture
 def image_classification_function_with_content(auth_test_user: User) -> Iterator[ImageClassificationFunction]:
-    func = ImageClassificationFunction.create_function("PYTHON-SDK IMAGE TEST FUNCTION", auth_test_user)
+    func = ImageClassificationFunction.create("PYTHON-SDK IMAGE TEST FUNCTION", auth_test_user)
     labels_to_create = [ClassificationLabel(name="Nice"), ClassificationLabel(name="Boo")]
     func.create_labels(labels_to_create)
     nice = ClassificationAnnotation(label_name="Nice")
@@ -99,7 +99,7 @@ def image_classification_function_with_content(auth_test_user: User) -> Iterator
 
 @pytest.fixture
 def tabular_classification_function(auth_test_user: User) -> Iterator[TabularClassificationFunction]:
-    func = TabularClassificationFunction.create_function("PYTHON-SDK TABULAR TEST FUNCTION", auth_test_user)
+    func = TabularClassificationFunction.create("PYTHON-SDK TABULAR TEST FUNCTION", auth_test_user)
     yield func
     func.delete()
 
@@ -108,7 +108,7 @@ def tabular_classification_function(auth_test_user: User) -> Iterator[TabularCla
 def tabular_classification_function_with_content(
     auth_test_user: User,
 ) -> Iterator[TabularClassificationFunction]:
-    func = TabularClassificationFunction.create_function("PYTHON-SDK TABULAR TEST FUNCTION", auth_test_user)
+    func = TabularClassificationFunction.create("PYTHON-SDK TABULAR TEST FUNCTION", auth_test_user)
     labels_to_create = [ClassificationLabel(name="Nice"), ClassificationLabel(name="Boo")]
     func.create_labels(labels_to_create)
     nice = ClassificationAnnotation(label_name="Nice")

--- a/tests/test_duplicates_handling.py
+++ b/tests/test_duplicates_handling.py
@@ -1,0 +1,18 @@
+from nyckel import TextClassificationFunction
+
+
+def test_samples(text_classification_function: TextClassificationFunction) -> None:
+    func = text_classification_function
+
+    sample_ids = func.create_samples(["hello", "goodbye"])
+
+    # Posting the same thing again, should return the same sample ids
+    same_sample_ids = func.create_samples(["hello", "goodbye"])
+
+    assert sample_ids == same_sample_ids
+
+    # Now post a mix of exisitng and new samples
+
+    new_sample_ids = func.create_samples(["hello", "goodday", "goodbye"])
+    assert [new_sample_ids[0], new_sample_ids[2]] == sample_ids
+    assert len(new_sample_ids) == 3

--- a/tests/test_field_handler.py
+++ b/tests/test_field_handler.py
@@ -1,13 +1,15 @@
 import time
 
-from nyckel import TabularClassificationFunction, User
+from nyckel import Credentials, TabularClassificationFunction
 from nyckel.functions.classification.tabular_classification import TabularFieldHandler, TabularFunctionField
 
 
-def test_fields(tabular_classification_function: TabularClassificationFunction, auth_test_user: User) -> None:
+def test_fields(
+    tabular_classification_function: TabularClassificationFunction, auth_test_credentials: Credentials
+) -> None:
     func = tabular_classification_function
     # Just borrow the function_id and create a TabularFieldHandler directly to test it.
-    fields_handler = TabularFieldHandler(func.function_id, auth_test_user)
+    fields_handler = TabularFieldHandler(func.function_id, auth_test_credentials)
 
     field = TabularFunctionField(name="Firstname", type="Text")
     field_id = fields_handler.create_fields([field])[0]

--- a/tests/test_image_classification_function.py
+++ b/tests/test_image_classification_function.py
@@ -4,7 +4,7 @@ from typing import Tuple, Union
 
 import numpy as np
 import pytest
-from conftest import get_test_user, make_random_image
+from conftest import get_test_credentials, make_random_image
 from nyckel import (
     ClassificationAnnotation,
     ClassificationLabel,
@@ -15,7 +15,7 @@ from nyckel import (
 from nyckel.functions.classification.image_classification import ImageDecoder
 from PIL import Image
 
-user = get_test_user()
+credentials = get_test_credentials()
 
 
 def test_samples(image_classification_function: ImageClassificationFunction) -> None:
@@ -78,7 +78,7 @@ def test_end_to_end(image_classification_function: ImageClassificationFunction) 
 
 
 @pytest.mark.skipif(
-    user.server_url == "http://localhost:5000",
+    credentials.server_url == "http://localhost:5000",
     reason="Integrity of image on copy is only implemented for images hosted on S3.",
 )
 def test_image_integrity_on_copy(image_classification_function: ImageClassificationFunction) -> None:

--- a/tests/test_image_classification_function.py
+++ b/tests/test_image_classification_function.py
@@ -68,7 +68,7 @@ def test_end_to_end(image_classification_function: ImageClassificationFunction) 
         print("-> No trained model yet. Sleeping 1 sec...")
         time.sleep(1)
 
-    assert isinstance(func(make_random_image()), ClassificationPrediction)
+    assert isinstance(func.invoke([make_random_image()])[0], ClassificationPrediction)
 
     assert len(func.invoke([make_random_image(), make_random_image(), make_random_image()])) == 3
 

--- a/tests/test_image_classification_function.py
+++ b/tests/test_image_classification_function.py
@@ -42,7 +42,7 @@ def test_samples(image_classification_function: ImageClassificationFunction) -> 
     assert len(samples_back) == 2
 
     # Check delete
-    func.delete_sample(sample_ids[0])
+    func.delete_samples(sample_ids[0:1])
     time.sleep(1)
     samples_back = func.list_samples()
     assert len(samples_back) == 1

--- a/tests/test_image_decoder.py
+++ b/tests/test_image_decoder.py
@@ -1,9 +1,8 @@
 import os
 from io import BytesIO
 
-from PIL import Image
-
 from nyckel.functions.classification.image_classification import ImageDecoder, ImageEncoder
+from PIL import Image
 
 image_url = "https://www.nyckel.com/blog/images/taimi-case-study-header-image.png"
 

--- a/tests/test_label_handler.py
+++ b/tests/test_label_handler.py
@@ -30,7 +30,7 @@ def test_labels(text_classification_function: TextClassificationFunction) -> Non
     assert set([label.name for label in labels]) == set(["Nice", "Nicer"])
 
     # And delete label
-    func.delete_label(nicer_label_id)
+    func.delete_labels([nicer_label_id])
     labels = func.list_labels()
     if not len(labels) == 1:
         # Give the API a chance to catch up.

--- a/tests/test_sample_handler.py
+++ b/tests/test_sample_handler.py
@@ -23,7 +23,8 @@ def test_duplicate_samples(text_classification_function: TextClassificationFunct
     ]
 
     sample_ids = func.create_samples(samples)
-    assert len(sample_ids) == 1  # Duplicate samples are ignored when posting.
+    assert len(sample_ids) == 2
+    assert sample_ids[0] == sample_ids[1]
 
 
 def test_update_annotation(text_classification_function: TextClassificationFunction) -> None:

--- a/tests/test_tabular_classification_function.py
+++ b/tests/test_tabular_classification_function.py
@@ -45,7 +45,7 @@ def test_end_to_end(tabular_classification_function: TabularClassificationFuncti
         print("-> No trained model yet. Sleeping 1 sec...")
         time.sleep(1)
 
-    prediction = func({"firstname": "Eric", "lastname": "Ebony"})
+    prediction = func.invoke([{"firstname": "Eric", "lastname": "Ebony"}])[0]
     assert isinstance(prediction, ClassificationPrediction)
 
     predictions = func.invoke(

--- a/tests/test_text_classification_function.py
+++ b/tests/test_text_classification_function.py
@@ -81,7 +81,7 @@ def test_end_to_end(text_classification_function: TextClassificationFunction) ->
         print("-> No trained model yet. Sleeping 1 sec...")
         time.sleep(1)
 
-    assert isinstance(func("Howdy"), ClassificationPrediction)
+    assert isinstance(func.invoke(["Howdy"])[0], ClassificationPrediction)
 
     assert len(func.invoke(["Hej", "Hola", "Gruezi"])) == 3
 

--- a/tests/test_text_classification_function.py
+++ b/tests/test_text_classification_function.py
@@ -31,7 +31,6 @@ def test_post_sample_overloading(
 
 def test_samples(text_classification_function: TextClassificationFunction) -> None:
     func = text_classification_function
-    # func = TextClassificationFunction.create_function("[TEST TEXT CLASSIFICATION SAMPLES]", auth_test_user)
     label = ClassificationLabel(name="Nice")
     func.create_labels([label])
 

--- a/tests/test_text_classification_function.py
+++ b/tests/test_text_classification_function.py
@@ -53,7 +53,7 @@ def test_samples(text_classification_function: TextClassificationFunction) -> No
     assert set([sample.data for sample in samples_back]) == set(["hello", "hello again"])
 
     # Check delete
-    func.delete_sample(sample_ids[0])
+    func.delete_samples(sample_ids[0:1])
     time.sleep(1)
     samples_back = func.list_samples()
     assert len(samples_back) == 1


### PR DESCRIPTION
- [x] Remove __call__ for invokes
- [x] Use .create() instead of .new().
- [x] Rename User to Credentials
- [x] Remove train_page and metrics properties on the main function classes
- [x] Remove singular versions of create and delete calls.
- [x] Fix create_sample return in case of duplicates
- [ ] Add SDK headers
- [ ] Check behavior on invoke retry if there are not enough samples
- [ ] Remove TabularFunctionField from docs
- [ ] Add basic docstrings to main methods
- [ ] Remove `__about__`